### PR TITLE
Changing the condition for sequence number exceeding maxSequence

### DIFF
--- a/src/main/java/com/gb/didgen/service/SnowflakeSequenceIdGenerator.java
+++ b/src/main/java/com/gb/didgen/service/SnowflakeSequenceIdGenerator.java
@@ -42,7 +42,7 @@ public class SnowflakeSequenceIdGenerator implements SequenceIdGenerator {
             }
             if (currentTimeStamp == lastTimestamp) {
                 currentSequence = currentSequence + 1 & maxSequence;
-                if (currentSequence == 0) {
+                if (currentSequence != 0) {
                     currentTimeStamp = waitNextMillis(currentTimeStamp);
                 }
             } else {


### PR DESCRIPTION
Should the condition not be if (currentSequence != 0) { ... }, otherwise it will always enter the if condition and do waitNextMillis. 